### PR TITLE
fix: typo

### DIFF
--- a/util.js
+++ b/util.js
@@ -849,7 +849,7 @@ var AwmUtil = {
     }
   },
   isTouchDevice: function () {
-    return (('ontouchstart' in window) || (navigator.msMaxTouchPoints > 0));
+    return (('ontouchstart' in window) || (navigator.maxTouchPoints > 0));
     //return true;
   },
   getPos: function (element, cursorLocation) {


### PR DESCRIPTION
I found a possible typo since the `navigator` has `maxTouchPoints` but no `msMaxTouchPoints` (unless you added it somewhere).